### PR TITLE
"d.midislap that" midislaps last w/random soundfont

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -77,7 +77,7 @@ class audio(commands.Cog):
 
         file_url = context[0]
         SF2 = context[1] + ".sf2" if context[1] else random.choice(sf2s)
-
+        if context[1] == 'that': SF2=random.choice(sf2s)
         with open(f'{dannybot}\\cache\\midislap.mid', 'wb') as midi_file:
             midi_file.write(requests.get(file_url).content)
 


### PR DESCRIPTION
at the moment you can midislap the last midi file sent in chat if you specify a soundfont, but this feature conflicts with running d.midislap on its own to list soundfonts, so i propose that "d.midislap that" (or "d.midislap random?") runs a random soundfont on the last midi sent